### PR TITLE
Disable cua key override

### DIFF
--- a/emacs/init.el
+++ b/emacs/init.el
@@ -34,6 +34,11 @@
 ;; Highlight matching parens
 (setq show-paren-mode t)
 
+;; To disable the overriding of standard Emacs binding by CUA mode,
+;; while retaining the other features of CUA mode described below, set
+;; the variable cua-enable-cua-keys to nil.
+(setq cua-enable-cua-keys nil)
+
 ;; Permanently force Emacs to indent with spaces, never with TABs
 (setq-default indent-tabs-mode nil)
 


### PR DESCRIPTION
All of a sudden ctrl-v acted as paste within emacs.  This appears to be CUA key bindings, but I have no idea how they became enabled.

https://www.gnu.org/software/emacs/manual/html_node/emacs/CUA-Bindings.html

This change disables the overriding of standard emacs bindinds by CUA mode.