### PR TITLE
Update copilot.el

### DIFF
--- a/emacs/init.el
+++ b/emacs/init.el
@@ -66,10 +66,6 @@
         s
         dash
         f
-        tree-sitter
-        tree-sitter-langs
-        markdown-mode
-        markdown-preview-mode
         ))
 
 (dolist (p my-packages)


### PR DESCRIPTION
Update https://github.com/copilot-emacs/copilot.el submodule to 88b10220.

This version requires emacs to install copilot server `M-x copilot-install-server`.